### PR TITLE
first commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,133 @@
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lock file
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform,osx,windows,linux
+
+# Massdriver generated files
+schema-artifacts.json
+schema-connections.json
+schema-params.json
+schema-ui.json
+
+# Auto generated terraform variable files
+**/_connections_variables.tf.json
+**/_md_variables.tf.json
+**/_params_variables.tf.json
+
+# For setting variable input values during local development
+**/*.tfvars.json
+**/*.tfvars
+
+
+### VS Code###
+# Plugins
+.infracost
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,81 @@
+---
+fail_fast: false
+repos:
+  - repo: local
+    hooks:
+      - id: mass-bundle-build
+        name: Build the bundle
+        entry: mass bundle build
+        language: system
+        pass_filenames: false
+      - id: valid-schema-params
+        name: Validate schema params
+        entry: mass schema validate -s https://json-schema.org/draft-07/schema -d ./schema-params.json
+        language: system
+        pass_filenames: false
+      - id: valid-schema-connections
+        name: Validate schema connections
+        entry: mass schema validate -s https://json-schema.org/draft-07/schema -d ./schema-connections.json
+        language: system
+        pass_filenames: false
+      - id: valid-schema-artifacts
+        name: Validate schema artifacts
+        entry: mass schema validate -s https://json-schema.org/draft-07/schema -d ./schema-artifacts.json
+        language: system
+        pass_filenames: false
+      - id: dev-params-validation
+        name: Validate development input params
+        entry: mass schema validate -s ./schema-params.json -d ./src/_params.auto.tfvars.json
+        language: system
+        pass_filenames: false
+      - id: conn-params-validation
+        name: Validate development connection params
+        entry: mass schema validate -s ./schema-connections.json -d ./src/_connections.auto.tfvars.json
+        language: system
+        pass_filenames: false
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.74.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: no-commit-to-branch
+        args:
+          - "-b"
+          - main
+  - repo: https://github.com/jaketf/jsonschema2md
+    rev: v0.9.0
+    hooks:
+      - id: jsonschema2md
+        name: jsonschema2md params
+        args:
+          - "./schema-params.json"
+          - "./README.md"
+          - "--token=PARAMS"
+          - "--omit-top-level-metadata"
+        pass_filenames: false
+      - id: jsonschema2md
+        name: jsonschema2md connections
+        args:
+          - "./schema-connections.json"
+          - "./README.md"
+          - "--token=CONNECTIONS"
+          - "--omit-top-level-metadata"
+        pass_filenames: false
+      - id: jsonschema2md
+        name: jsonschema2md artifacts
+        args:
+          - "./schema-artifacts.json"
+          - "./README.md"
+          - "--token=ARTIFACTS"
+          - "--omit-top-level-metadata"
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL:=/bin/bash
+TAG=release-$(shell date +%s)
+# NOTE: this is a temporary file, this will be baked into the cli down the road.
+.PHONY: plan
+
+plan: ## Plans all examples
+	mass bundle build
+	ruby ./tf_helper.rb plan | bash
+
+apply: ## Applies all examples
+	mass bundle build
+	ruby ./tf_helper.rb apply | bash
+
+destroy: ## Destroys all examples
+	mass bundle build
+	ruby ./tf_helper.rb destroy | bash
+
+.PHONY: release
+release:
+	@if ! command -v gh  &> /dev/null; then echo "please install gh cli https://github.com/cli/cli#installation" && exit 1; fi
+	@if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then echo "releasing is only supported from tip of origin/main currently: $(git rev-parse origin/main). Please git checkout main && git reset --hard origin/main and try again." && exit 1; fi
+	gh release create ${TAG} --generate-notes --draft

--- a/README.md
+++ b/README.md
@@ -1,1 +1,440 @@
+[![Massdriver][logo]][website]
+
 # aws-vpc-peering-connection
+
+[![Release][release_shield]][release_url]
+[![Contributors][contributors_shield]][contributors_url]
+[![Forks][forks_shield]][forks_url]
+[![Stargazers][stars_shield]][stars_url]
+[![Issues][issues_shield]][issues_url]
+[![MIT License][license_shield]][license_url]
+
+An AWS VPC Peering Connection is a networking connection between two VPCs that enables you to route traffic between them privately.
+
+---
+
+## Design
+
+For detailed information, check out our [Operator Guide](operator.mdx) for this bundle.
+
+## Usage
+
+Our bundles aren't intended to be used locally, outside of testing. Instead, our bundles are designed to be configured, connected, deployed and monitored in the [Massdriver][website] platform.
+
+### What are Bundles?
+
+Bundles are the basic building blocks of infrastructure, applications, and architectures in [Massdriver][website]. Read more [here](https://docs.massdriver.cloud/concepts/bundles).
+
+## Bundle
+
+<!-- COMPLIANCE:START -->
+
+Security and compliance scanning of our bundles is performed using [Bridgecrew](https://www.bridgecrew.cloud/). Massdriver also offers security and compliance scanning of operational infrastructure configured and deployed using the platform.
+
+| Benchmark                                                                                                                                                                                                                                                       | Description                        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/cis_aws>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance || [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/
+aws-vpc-peering-connection/pci>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/nist>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/iso>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/soc2>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/massdriver-cloud/aws-vpc-peering-connection/hipaa>)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=massdriver-cloud%2Faws-vpc-peering-connection&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+<!-- COMPLIANCE:END -->
+
+### Params
+
+Form input parameters for configuring a bundle for deployment.
+
+<details>
+<summary>View</summary>
+
+<!-- PARAMS:START -->
+## Properties
+
+- **`accepter_vpc_arn`** *(string)*: **IMPORTANT: Only set this value if you haven't connected a remote "accepter" VPC to the bundle!!!**
+ If an accepter VPC is connected, this field is ignored and the value will be extracted from the connection artifact. Use this field if the remote VPC isn't managed by Massdriver or exists in different AWS account than the requester VPC. **This will require you to [accept the peering connection](https://docs.aws.amazon.com/vpc/latest/peering/accept-vpc-peering-connection.html) and [update the route tables](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) of the accepter VPC manually**!
+
+  Examples:
+  ```json
+  "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+  ```
+
+  ```json
+  "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+  ```
+
+- **`accepter_vpc_cidr`** *(string)*: **IMPORTANT: Only set this value if you haven't connected a remote "accepter" VPC to the bundle!!!**
+ If an accepter VPC is connected, this field is ignored and the value will be extracted from the connection artifact. Use this field if the remote VPC isn't managed by Massdriver or exists in different AWS account than the requester VPC. **This will require you to [accept the peering connection](https://docs.aws.amazon.com/vpc/latest/peering/accept-vpc-peering-connection.html) and [update the route tables](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) of the accepter VPC manually**!
+<!-- PARAMS:END -->
+
+</details>
+
+### Connections
+
+Connections from other bundles that this bundle depends on.
+
+<details>
+<summary>View</summary>
+
+<!-- CONNECTIONS:START -->
+## Properties
+
+- **`accepter`** *(object)*: . Cannot contain additional properties.
+  - **`data`** *(object)*
+    - **`infrastructure`** *(object)*
+      - **`arn`** *(string)*: Amazon Resource Name.
+
+        Examples:
+        ```json
+        "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+        ```
+
+        ```json
+        "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+        ```
+
+      - **`cidr`** *(string)*
+
+        Examples:
+        ```json
+        "10.100.0.0/16"
+        ```
+
+        ```json
+        "192.24.12.0/22"
+        ```
+
+      - **`internal_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+      - **`private_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+      - **`public_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+  - **`specs`** *(object)*
+    - **`aws`** *(object)*: .
+      - **`region`** *(string)*: AWS Region to provision in.
+
+        Examples:
+        ```json
+        "us-west-2"
+        ```
+
+- **`aws_authentication`** *(object)*: . Cannot contain additional properties.
+  - **`data`** *(object)*
+    - **`arn`** *(string)*: Amazon Resource Name.
+
+      Examples:
+      ```json
+      "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+      ```
+
+      ```json
+      "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+      ```
+
+    - **`external_id`** *(string)*: An external ID is a piece of data that can be passed to the AssumeRole API of the Security Token Service (STS). You can then use the external ID in the condition element in a role's trust policy, allowing the role to be assumed only when a certain value is present in the external ID.
+  - **`specs`** *(object)*
+    - **`aws`** *(object)*: .
+      - **`region`** *(string)*: AWS Region to provision in.
+
+        Examples:
+        ```json
+        "us-west-2"
+        ```
+
+- **`requester`** *(object)*: . Cannot contain additional properties.
+  - **`data`** *(object)*
+    - **`infrastructure`** *(object)*
+      - **`arn`** *(string)*: Amazon Resource Name.
+
+        Examples:
+        ```json
+        "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+        ```
+
+        ```json
+        "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+        ```
+
+      - **`cidr`** *(string)*
+
+        Examples:
+        ```json
+        "10.100.0.0/16"
+        ```
+
+        ```json
+        "192.24.12.0/22"
+        ```
+
+      - **`internal_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+      - **`private_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+      - **`public_subnets`** *(array)*
+        - **Items** *(object)*: AWS VCP Subnet.
+          - **`arn`** *(string)*: Amazon Resource Name.
+
+            Examples:
+            ```json
+            "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+            ```
+
+            ```json
+            "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+            ```
+
+          - **`aws_zone`** *(string)*: AWS Availability Zone.
+
+            Examples:
+          - **`cidr`** *(string)*
+
+            Examples:
+            ```json
+            "10.100.0.0/16"
+            ```
+
+            ```json
+            "192.24.12.0/22"
+            ```
+
+
+          Examples:
+  - **`specs`** *(object)*
+    - **`aws`** *(object)*: .
+      - **`region`** *(string)*: AWS Region to provision in.
+
+        Examples:
+        ```json
+        "us-west-2"
+        ```
+
+<!-- CONNECTIONS:END -->
+
+</details>
+
+### Artifacts
+
+Resources created by this bundle that can be connected to other bundles.
+
+<details>
+<summary>View</summary>
+
+<!-- ARTIFACTS:START -->
+## Properties
+
+<!-- ARTIFACTS:END -->
+
+</details>
+
+## Contributing
+
+<!-- CONTRIBUTING:START -->
+
+### Bug Reports & Feature Requests
+
+Did we miss something? Please [submit an issue](https://github.com/massdriver-cloud/aws-vpc-peering-connection/issues>) to report any bugs or request additional features.
+
+### Developing
+
+**Note**: Massdriver bundles are intended to be tightly use-case scoped, intention-based, reusable pieces of IaC for use in the [Massdriver][website] platform. For this reason, major feature additions that broaden the scope of an existing bundle are likely to be rejected by the community.
+
+Still want to get involved? First check out our [contribution guidelines](https://docs.massdriver.cloud/bundles/contributing).
+
+### Fix or Fork
+
+If your use-case isn't covered by this bundle, you can still get involved! Massdriver is designed to be an extensible platform. Fork this bundle, or [create your own bundle from scratch](https://docs.massdriver.cloud/bundles/development)!
+
+<!-- CONTRIBUTING:END -->
+
+## Connect
+
+<!-- CONNECT:START -->
+
+Questions? Concerns? Adulations? We'd love to hear from you!
+
+Please connect with us!
+
+[![Email][email_shield]][email_url]
+[![GitHub][github_shield]][github_url]
+[![LinkedIn][linkedin_shield]][linkedin_url]
+[![Twitter][twitter_shield]][twitter_url]
+[![YouTube][youtube_shield]][youtube_url]
+[![Reddit][reddit_shield]][reddit_url]
+
+
+<!-- markdownlint-disable -->
+
+[logo]: https://raw.githubusercontent.com/massdriver-cloud/docs/main/static/img/logo-with-logotype-horizontal-400x110.svg
+
+[docs]: https://docs.massdriver.cloud?utm_source=aws-vpc-peering-connection&utm_medium=aws-vpc-peering-connection&utm_campaign=aws-vpc-peering-connection&utm_content=aws-vpc-peering-connection
+[website]: https://www.massdriver.cloud?utm_source=aws-vpc-peering-connection&utm_medium=aws-vpc-peering-connection&utm_campaign=aws-vpc-peering-connection&utm_content=aws-vpc-peering-connection
+[github]: https://github.com/massdriver-cloud
+[linkedin]: https://www.linkedin.com/company/massdriver/
+
+[contributors_shield]: https://img.shields.io/github/contributors/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[contributors_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/graphs/contributors>
+[forks_shield]: https://img.shields.io/github/forks/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[forks_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/network/members>
+[stars_shield]: https://img.shields.io/github/stars/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[stars_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/stargazers>
+[issues_shield]: https://img.shields.io/github/issues/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[issues_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/issues>
+[release_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/releases/latest>
+[release_shield]: https://img.shields.io/github/release/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[license_shield]: https://img.shields.io/github/license/massdriver-cloud/aws-vpc-peering-connection.svg?style=for-the-badge>
+[license_url]: https://github.com/massdriver-cloud/aws-vpc-peering-connection/blob/main/LICENSE>
+
+[email_url]: mailto:support@massdriver.cloud
+[email_shield]: https://img.shields.io/badge/email-Massdriver-black.svg?style=for-the-badge&logo=mail.ru&color=000000
+[github_url]: mailto:support@massdriver.cloud
+[github_shield]: https://img.shields.io/badge/follow-Github-black.svg?style=for-the-badge&logo=github&color=181717
+[linkedin_url]: https://linkedin.com/in/massdriver-cloud
+[linkedin_shield]: https://img.shields.io/badge/follow-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&color=0A66C2
+[twitter_url]: https://twitter.com/massdriver
+[twitter_shield]: https://img.shields.io/badge/follow-Twitter-black.svg?style=for-the-badge&logo=twitter&color=1DA1F2
+[youtube_url]: https://www.youtube.com/channel/UCfj8P7MJcdlem2DJpvymtaQ
+[youtube_shield]: https://img.shields.io/badge/subscribe-Youtube-black.svg?style=for-the-badge&logo=youtube&color=FF0000
+[reddit_url]: https://www.reddit.com/r/massdriver
+[reddit_shield]: https://img.shields.io/badge/subscribe-Reddit-black.svg?style=for-the-badge&logo=reddit&color=FF4500
+
+<!-- markdownlint-restore -->
+
+<!-- CONNECT:END -->

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M38.06 26.151v11.473L48 31.891V20.406l-9.94 5.745z" fill="#4040B2"/><path d="m27.03 20.406 9.94 5.745v11.473l-9.94-5.74V20.407zM16 14v11.479l9.94 5.74v-11.48L16 14zm11.03 30.624 9.94 5.74v-11.48l-9.94-5.739v11.48z" fill="#5C4EE5"/></svg>

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -1,0 +1,48 @@
+schema: draft-07
+name: "aws-vpc-peering-connection"
+description: "An AWS VPC Peering Connection is a networking connection between two VPCs that enables you to route traffic between them privately."
+source_url: github.com/massdriver-cloud/aws-vpc-peering-connection
+access: private
+type: "infrastructure"
+
+
+params:
+  properties:
+    accepter_vpc_arn:
+      type: string
+      title: Remote VPC ARN
+      description: "**IMPORTANT: Only set this value if you haven't connected a remote \"accepter\" VPC to the bundle!!!**\n If an accepter VPC is connected, this field is ignored and the value will be extracted from the connection artifact. Use this field if the remote VPC isn't managed by Massdriver or exists in different AWS account than the requester VPC. **This will require you to [accept the peering connection](https://docs.aws.amazon.com/vpc/latest/peering/accept-vpc-peering-connection.html) and [update the route tables](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) of the accepter VPC manually**!"
+      $md.immutable: true
+      $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/aws-arn.json
+    accepter_vpc_cidr:
+      type: string
+      title: Remote VPC CIDR
+      description: "**IMPORTANT: Only set this value if you haven't connected a remote \"accepter\" VPC to the bundle!!!**\n If an accepter VPC is connected, this field is ignored and the value will be extracted from the connection artifact. Use this field if the remote VPC isn't managed by Massdriver or exists in different AWS account than the requester VPC. **This will require you to [accept the peering connection](https://docs.aws.amazon.com/vpc/latest/peering/accept-vpc-peering-connection.html) and [update the route tables](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) of the accepter VPC manually**!"
+      $md.immutable: true
+      pattern: ^(?:10\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)(?:\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){2}(?:/(?:1[6-9]|2[0-4]))$
+      message:
+        pattern: Range must be from private networking space (10.X.X.X, 172.16-31.X.X, 192.168.X.X). Mask must be between 16 and 24
+
+
+connections:
+  required:
+  - aws_authentication
+  - requester
+  properties:
+    aws_authentication:
+      $ref: massdriver/aws-iam-role
+    requester:
+      $ref: massdriver/aws-vpc
+    accepter:
+      $ref: massdriver/aws-vpc
+
+
+artifacts:
+  properties: {}
+
+
+ui:
+  ui:order:
+    - accepter_vpc_arn
+    - accepter_vpc_cidr
+    - "*"

--- a/operator.mdx
+++ b/operator.mdx
@@ -1,0 +1,5 @@
+# Operator Guide
+
+This is the guide for your bundle. It will appear under the `guide` button in Massdriver.
+
+Use it to describe to users how the bundle works, use cases for the bundle, and examples.

--- a/src/_providers.tf
+++ b/src/_providers.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    massdriver = {
+      source  = "massdriver-cloud/massdriver"
+      version = "~> 1.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "requester"
+  region = var.requester.specs.aws.region
+  assume_role {
+    role_arn    = var.aws_authentication.data.arn
+    external_id = var.aws_authentication.data.external_id
+  }
+  default_tags {
+    tags = var.md_metadata.default_tags
+  }
+}
+
+provider "aws" {
+  alias  = "accepter"
+  region = try(var.accepter.specs.aws.region, var.requester.specs.aws.region)
+  assume_role {
+    role_arn    = var.aws_authentication.data.arn
+    external_id = var.aws_authentication.data.external_id
+  }
+  default_tags {
+    tags = var.md_metadata.default_tags
+  }
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,0 +1,65 @@
+locals {
+  create_accepter = var.accepter != null ? true : false
+
+  # same_account = data.aws_arn.requester_vpc.account == data.aws_arn.accepter_vpc.account
+  # same_region  = data.aws_arn.requester_vpc.region == data.aws_arn.accepter_vpc.region
+
+  requester_vpc_id   = element(split("/", var.requester.data.infrastructure.arn), 1)
+  requester_vpc_cidr = var.requester.data.infrastructure.cidr
+
+  accepter_vpc_cidr    = try(var.accepter.data.infrastructure.cidr, var.accepter_vpc_cidr)
+  accepter_vpc_id      = element(split("/", data.aws_arn.accepter_vpc.resource), 1)
+  accepter_vpc_region  = data.aws_arn.accepter_vpc.region
+  accepter_vpc_account = data.aws_arn.accepter_vpc.account
+}
+
+data "aws_arn" "requester_vpc" {
+  arn = var.requester.data.infrastructure.arn
+}
+data "aws_arn" "accepter_vpc" {
+  arn = try(var.accepter.data.infrastructure.arn, var.accepter_vpc_arn)
+}
+
+resource "aws_vpc_peering_connection" "requester" {
+  provider      = aws.requester
+  vpc_id        = local.requester_vpc_id
+  peer_vpc_id   = local.accepter_vpc_id
+  peer_owner_id = local.accepter_vpc_account
+  peer_region   = local.accepter_vpc_region
+  auto_accept   = false
+
+  tags = {
+    Side = "Requester"
+  }
+}
+
+resource "aws_vpc_peering_connection_accepter" "accepter" {
+  count                     = local.create_accepter ? 1 : 0
+  provider                  = aws.accepter
+  vpc_peering_connection_id = aws_vpc_peering_connection.requester.id
+  auto_accept               = true
+
+  tags = {
+    Side = "Accepter"
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "requester" {
+  count                     = local.create_accepter ? 1 : 0
+  provider                  = aws.requester
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.accepter.0.id
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "accepter" {
+  count                     = local.create_accepter ? 1 : 0
+  provider                  = aws.accepter
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.accepter.0.id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}

--- a/src/routes.tf
+++ b/src/routes.tf
@@ -1,0 +1,28 @@
+data "aws_route_tables" "requester" {
+  provider = aws.requester
+  vpc_id   = local.requester_vpc_id
+}
+
+data "aws_route_tables" "accepter" {
+  count    = local.create_accepter ? 1 : 0
+  provider = aws.accepter
+  vpc_id   = local.accepter_vpc_id
+}
+
+resource "aws_route" "requester" {
+  for_each = toset(data.aws_route_tables.requester.ids)
+  provider = aws.requester
+
+  route_table_id            = each.key
+  destination_cidr_block    = local.accepter_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.requester.id
+}
+
+resource "aws_route" "accepter" {
+  for_each = local.create_accepter ? toset(data.aws_route_tables.accepter.0.ids) : toset([])
+  provider = aws.accepter
+
+  route_table_id            = each.key
+  destination_cidr_block    = local.requester_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.accepter.0.id
+}

--- a/src/validations.json
+++ b/src/validations.json
@@ -1,0 +1,5 @@
+{
+    "do_not_delete": [
+        "aws_vpc_peering_connection.requester"
+    ]
+}

--- a/tf_helper.rb
+++ b/tf_helper.rb
@@ -1,0 +1,59 @@
+#! ruby
+# NOTE: this is a temporary file, this will be baked into the cli down the road.
+
+require 'json'
+
+terraform_cmd = ARGV[0]
+
+bundle_name = File.basename(__dir__)
+schema_params = File.read("./schema-params.json")
+params = JSON.parse(schema_params)
+
+examples = params["examples"]
+template_params_file = File.read("./src/dev.params.tfvars.json")
+
+$all_cmds = []
+
+examples.each do |example|
+  name = example.delete("__name")
+  slug_safe_name = name.downcase.gsub(/[^a-z0-9]/, "")
+  outfile = "/tmp/#{rand(10000000)}.params.tfvars.json"
+
+  example_dev_params_file = template_params_file.gsub("PLACEHOLDER", slug_safe_name)
+  example_dev_base_params = JSON.parse(example_dev_params_file)
+  example_params = example_dev_base_params.merge(example)
+
+  this_run_tfvars_json = File.open(outfile, "w+") do |f|
+    f.puts JSON.pretty_generate(example_params)
+  end
+
+  var_files = "-var-file ./dev.connections.tfvars.json -var-file #{outfile}"
+
+  cmd = [
+    %Q{echo Example: #{name} Params: #{outfile} Workspace: #{slug_safe_name}},
+    "pushd ./src",
+    "terraform init",
+    "terraform workspace new #{slug_safe_name} || terraform workspace select #{slug_safe_name}"
+  ]
+
+  addl_cmds = {
+    "plan" => [
+      "terraform plan #{var_files}"
+    ],
+    "destroy" => [
+      "terraform destroy #{var_files} -auto-approve"
+    ],
+    "apply" => [
+      "terraform apply #{var_files} -auto-approve"
+    ]
+  }
+
+  final_cmds = [
+    "popd"
+  ]
+
+  cmd += (addl_cmds[terraform_cmd] + final_cmds)
+  $all_cmds += (cmd)
+end
+
+puts $all_cmds.join(' && ')


### PR DESCRIPTION
There are 2 peering scenarios, and this bundle supports both:

1. The user has 2 VPCs in the same account, both provisioned by massdriver
2. The user has 2 VPCs, but they're either not both in massdriver, or in different accounts

There are 2 VPC connections (`requester` and `accepter`), but only 1 is required (`requester`). If the `accepter` connection is also hooked up, Massdriver will attempt to manage the full peering connection - request peering, accept peering, and add entries to both VPC's route tables.

If the `accepter` connection isn't hooked up, there are 2 params the user must set: Remote VPC ARN and CIDR. Using those values, we can initiate a peering connection request, and update the requestor VPC route tables, but the rest is left up to the user (accepting the connection and updating accepter VPC route tables).

This makes the bundle work 100% for 2 Massdriver VPCs, and ~50% for 1 Massdriver VPC and 1 non-Massdriver or separate account VPC.